### PR TITLE
Move from GitLab Pages to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,63 @@
+name: Deploy Wasmgrind Book and Docs.rs to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MDBOOK_VERSION: 0.4.51
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust and mdBook
+        run: |
+          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
+          rustup update
+          cargo install --version ${MDBOOK_VERSION} mdbook
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Setup Deployment Directory
+        run: mkdir public
+      - name: Build Wasmgrind Book with mdBook
+        working-directory: ./book
+        run: mdbook build -d ../public
+      - name: Build Wasmgrind Docs.rs with cargo
+        run: cargo doc --workspace --release
+      - name: Move Wasmgrind Docs.rs to deployment directory
+        run: mv target/doc public/wasmgrind-docs-rs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Otherwise install it:
     cargo install wasm-pack
 
 ## Quick Start Guide
-The following sections describe how to get up and running with wasmgrind quickly. For more in-depth explainations refer to the [Wasmgrind Book](https://wasmgrind-d6f2b1.gitlab.io/book/).
+The following sections describe how to get up and running with wasmgrind quickly. For more in-depth explainations refer to the [Wasmgrind Book](https://afkoffee.github.io/wasmgrind/).
 
 ### Compiling Binaries for Wasmgrind
 Wasmgrind assumes that the provided WebAssembly binary imports a set of API functions needed to create and join threads as well as to record important events for tracing.  Currently, the only two ways to utilize this API is to either use the [wasm-threadlink](crates/wasm-threadlink/) crate in your project or to wrap the internal API using your own code. 

--- a/book/src/developers_guide/wasmgrind_js/npm_package.md
+++ b/book/src/developers_guide/wasmgrind_js/npm_package.md
@@ -43,4 +43,4 @@ export class TraceOutput {
 }
 ```
 
-These exports refer to Rust functions and structs that are exported by the wasmgrind-js crate. See the [wasmgrind-js docs](https://wasmgrind-d6f2b1.gitlab.io/docs/wasmgrind_js/) for further information.
+These exports refer to Rust functions and structs that are exported by the wasmgrind-js crate. See the [wasmgrind-js docs](https://afkoffee.github.io/wasmgrind/wasmgrind-docs-rs/wasmgrind_js/) for further information.

--- a/book/src/user_guide/compiling_the_binary/using_wasm_threadlink.md
+++ b/book/src/user_guide/compiling_the_binary/using_wasm_threadlink.md
@@ -1,5 +1,5 @@
 # Using Wasm-Threadlink
-The _wasm-threadlink_ Rust library offers an ideomatic way of accessing the internal runtime ABI of Wasmgrind from Rust program. It provides two main utilities: a modified mutex structure, which enables tracing of lock events, and functions for thread creation and joining. Refer to [docs.rs](https://wasmgrind-d6f2b1.gitlab.io/docs/wasmgrind/) for a more detailed API documentation.
+The _wasm-threadlink_ Rust library offers an ideomatic way of accessing the internal runtime ABI of Wasmgrind from Rust program. It provides two main utilities: a modified mutex structure, which enables tracing of lock events, and functions for thread creation and joining. Refer to [docs.rs](https://afkoffee.github.io/wasmgrind/wasmgrind-docs-rs/wasmgrind/) for a more detailed API documentation.
 
 **Note:** If the `tracing` feature of the crate is enabled, it wraps the _tracing extended_ internal runtime ABI. Otherwise, it just wraps the _standalone_ internal runtime ABI.
 

--- a/book/src/user_guide/native_environments.md
+++ b/book/src/user_guide/native_environments.md
@@ -31,4 +31,4 @@ Emits the WebAssembly binary into a `tmp` folder (creating it if necessary) afte
 ## Wasmgrind as a Library
 If the WebAssembly binary to be examined depends on custom function imports, you have to use Wasmgrind as a library and embedd it into your project. This gives you control over additional imports that should be present upon instantiating your module.
 
-For usage instructions with regard to the Rust library API, refer to the [wasmgrind docs.rs](https://wasmgrind-d6f2b1.gitlab.io/docs/wasmgrind/) site.
+For usage instructions with regard to the Rust library API, refer to the [wasmgrind docs.rs](https://afkoffee.github.io/wasmgrind/wasmgrind-docs-rs/wasmgrind/) site.

--- a/book/src/user_guide/web_environments.md
+++ b/book/src/user_guide/web_environments.md
@@ -86,7 +86,7 @@ The output of this command should be located under `crates/wasmgrind-js/pkg`. Li
     npm link /path/to/wasmgrind-js/pkg
 
 ### 3. Create an `index.html` and `index.js` to execute Wasmgrind
-Wasmgrind offers a reduced set of API functions on the web compared to native hosts. Refer to the [wasmgrind-js docs](https://wasmgrind-d6f2b1.gitlab.io/docs/wasmgrind_js/) for further information. The following snippets show how to generate and download a simple execution trace with Wasmgrind on the web.
+Wasmgrind offers a reduced set of API functions on the web compared to native hosts. Refer to the [wasmgrind-js docs](https://afkoffee.github.io/wasmgrind/wasmgrind-docs-rs/wasmgrind_js/) for further information. The following snippets show how to generate and download a simple execution trace with Wasmgrind on the web.
 
 As we have specified the `index.js` in our webpack configuration, we have to provide one:
 ```javascript

--- a/crates/alloc-exposer/README.md
+++ b/crates/alloc-exposer/README.md
@@ -10,7 +10,7 @@ While it can be compiled on platforms other than WebAssembly, this crate is inte
 be used only in binaries that will be compiled to WebAssembly and processed by 
 [`wasm-threadify`] afterwards.
 
-[`wasm-threadify`]: https://wasmgrind-d6f2b1.gitlab.io/docs/wasm_threadify/index.html
+[`wasm-threadify`]: https://afkoffee.github.io/wasmgrind/wasmgrind-docs-rs/wasm_threadify/index.html
 
 ## Third Party Materials
 The following files in this directory (including its subdirectories) contain code by

--- a/crates/alloc-exposer/src/lib.rs
+++ b/crates/alloc-exposer/src/lib.rs
@@ -8,7 +8,7 @@
 //! be used only in binaries that will be compiled to WebAssembly and processed by 
 //! [`wasm-threadify`] afterwards.
 //! 
-//! [`wasm-threadify`]: https://wasmgrind-d6f2b1.gitlab.io/docs/wasm_threadify/index.html
+//! [`wasm-threadify`]: https://afkoffee.github.io/wasmgrind/wasmgrind-docs-rs/wasm_threadify/index.html
 
 /*
 * The code in this file is mainly based on and taken from the wasm-bindgen tool:

--- a/crates/race-detection/src/tracing.rs
+++ b/crates/race-detection/src/tracing.rs
@@ -59,7 +59,7 @@ impl Tracing {
     ///
     /// This method will lock the internal execution trace
     /// iterates over all collected events and creates a binary trace in
-    /// [RapidBin](https://wasmgrind-d6f2b1.gitlab.io/book/developers_guide/race_detection/rapid_bin.html)
+    /// [RapidBin](https://afkoffee.github.io/wasmgrind/developers_guide/race_detection/rapid_bin.html)
     /// format.
     ///
     /// # Errors

--- a/crates/wasmgrind-core/src/patching.rs
+++ b/crates/wasmgrind-core/src/patching.rs
@@ -36,7 +36,7 @@ pub fn threadify(wasm_bytes: &[u8]) -> Result<Vec<u8>, Error> {
 /// Wasabi version](https://github.com/AFKoffee/wasabi.git).
 /// 
 /// For details with regard to the exact instrumentation performed, refer to the
-/// [Wasmgrind Book](https://wasmgrind-d6f2b1.gitlab.io/book/developers_guide/wasmgrind_core/wasm_instrumentation.html).
+/// [Wasmgrind Book](https://afkoffee.github.io/wasmgrind/developers_guide/wasmgrind_core/wasm_instrumentation.html).
 /// 
 /// This function may fail in the following cases:
 /// - The given buffer `wasm_bytes` could not be parsed by Wasabi.

--- a/crates/wasmgrind-js/src/lib.rs
+++ b/crates/wasmgrind-js/src/lib.rs
@@ -53,7 +53,7 @@ extern "C" {
 ///
 /// The `binary` argument should be an URL to a valid WebAssembly module in binary format, which
 /// was compiled against the _tracing-extended_ Wasmgrind ABI. For details refer to the
-/// [Wasmgrind Book](https://wasmgrind-d6f2b1.gitlab.io/book/user_guide/compiling_the_binary.html).
+/// [Wasmgrind Book](https://afkoffee.github.io/wasmgrind/user_guide/compiling_the_binary.html).
 ///
 /// # Errors
 /// The function will fail if the provided WebAssembly binary could not be patched or instrumented
@@ -94,7 +94,7 @@ pub async fn grind(binary: Url, function_name: JsString) -> Result<JsValue, JsVa
 ///
 /// The `binary` argument should be an URL to a valid WebAssembly module in binary format, which
 /// was compiled against the _standalone_ Wasmgrind ABI. For details refer to the
-/// [Wasmgrind Book](https://wasmgrind-d6f2b1.gitlab.io/book/user_guide/compiling_the_binary.html).
+/// [Wasmgrind Book](https://afkoffee.github.io/wasmgrind/user_guide/compiling_the_binary.html).
 ///
 /// # Errors
 /// The function will fail if the provided WebAssembly binary could not be patched for any reason.

--- a/crates/wasmgrind-js/src/runtime/wasmgrind.rs
+++ b/crates/wasmgrind-js/src/runtime/wasmgrind.rs
@@ -78,7 +78,7 @@ impl WasmgrindRuntime {
     ///
     /// This method will lock the internal execution trace structure 
     /// iterates over all collected events and creates a binary trace in
-    /// [RapidBin](https://wasmgrind-d6f2b1.gitlab.io/book/developers_guide/race_detection/rapid_bin.html)
+    /// [RapidBin](https://afkoffee.github.io/wasmgrind/developers_guide/race_detection/rapid_bin.html)
     /// format.
     /// 
     /// The excution trace is returned in form of a [`js_sys::Promise`] that wrapps a [`TraceOutput`] object.

--- a/crates/wasmgrind-macros/src/lib.rs
+++ b/crates/wasmgrind-macros/src/lib.rs
@@ -14,7 +14,7 @@ mod thread_join;
 /// 3. a [`wasmtime::SharedMemory`](https://docs.rs/wasmtime/33.0.0/wasmtime/struct.SharedMemory.html)
 /// 4. a [`wasmtime::Linker`](https://docs.rs/wasmtime/33.0.0/wasmtime/struct.Linker.html)
 /// 5. a `wasmtime::runtime::Tmgmt` (internal thread management of wasmgrind)
-/// 6. Optional: a [`race_detection::Tracing`](https://wasmgrind-d6f2b1.gitlab.io/docs/race_detection/struct.Tracing.html)
+/// 6. Optional: a [`race_detection::Tracing`](https://afkoffee.github.io/wasmgrind/wasmgrind-docs-rs/race_detection/struct.Tracing.html)
 ///    wrapped in a [`std::sync::Arc`].
 /// 
 /// The returned Rust closure implements the `thread_create` function of the internal runtime ABI.
@@ -29,7 +29,7 @@ pub fn thread_create_func(input: TokenStream) -> TokenStream {
 /// 
 /// This macro accepts 1 required and 1 optional argument:
 /// 1. a `wasmtime::runtime::Tmgmt` (internal thread management of wasmgrind)
-/// 2. Optional: a [`race_detection::Tracing`](https://wasmgrind-d6f2b1.gitlab.io/docs/race_detection/struct.Tracing.html) 
+/// 2. Optional: a [`race_detection::Tracing`](https://afkoffee.github.io/wasmgrind/wasmgrind-docs-rs/race_detection/struct.Tracing.html) 
 ///    wrapped in a [`std::sync::Arc`].
 /// 
 /// The returned Rust closure implements the `thread_create` function of the internal runtime ABI.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ fn patch_binary<P: AsRef<Path>>(binary: P, emit_patched: bool) -> Result<Vec<u8>
 ///
 /// The `binary` argument should be a path to a valid WebAssembly module in binary format, which
 /// was compiled against the _tracing-extended_ Wasmgrind ABI. For details refer to the
-/// [Wasmgrind Book](https://wasmgrind-d6f2b1.gitlab.io/book/user_guide/compiling_the_binary.html).
+/// [Wasmgrind Book](https://afkoffee.github.io/wasmgrind/user_guide/compiling_the_binary.html).
 ///
 /// If the `emit_patched` flag is set to `true`, the state of the WebAssembly module after
 /// patching will be emitted to a `tmp` folder relative to the current working directory.
@@ -157,7 +157,7 @@ pub fn grind<P: AsRef<Path>>(
 ///
 /// The `binary` argument should be a path to a valid WebAssembly module in binary format, which
 /// was compiled against the _standalone_ Wasmgrind ABI. For details refer to the
-/// [Wasmgrind Book](https://wasmgrind-d6f2b1.gitlab.io/book/user_guide/compiling_the_binary.html).
+/// [Wasmgrind Book](https://afkoffee.github.io/wasmgrind/user_guide/compiling_the_binary.html).
 ///
 /// If the `emit_patched` flag is set to `true`, the state of the WebAssembly module after
 /// patching will be emitted to a `tmp` folder relative to the current working directory.

--- a/src/runtime/tracing.rs
+++ b/src/runtime/tracing.rs
@@ -58,7 +58,7 @@ impl WasmgrindRuntime {
     ///
     /// This method will lock the internal execution trace structure 
     /// iterates over all collected events and creates a binary trace in
-    /// [RapidBin](https://wasmgrind-d6f2b1.gitlab.io/book/developers_guide/race_detection/rapid_bin.html)
+    /// [RapidBin](https://afkoffee.github.io/wasmgrind/developers_guide/race_detection/rapid_bin.html)
     /// format.
     /// 
     /// Refer to [`race_detection::tracing::Tracing`] for further information with regard to execution tracing


### PR DESCRIPTION
This PR introduces a GitHub actions workflow to publish the Wasmgrind Book and Docs.rs to GitHub Pages.

**Important:** Currently, the links in Book and Docs.rs use the domain of the fork (afkoffee.github.io). This needs to be updated to the domain of the organization before the PR can be merged.